### PR TITLE
Support Phi3SuScaledRotaryEmbedding for 128k model

### DIFF
--- a/vllm/model_executor/models/mixtral.py
+++ b/vllm/model_executor/models/mixtral.py
@@ -452,6 +452,7 @@ class PhiMoEAttention(nn.Module):
             max_position=max_position,
             base=int(self.rope_theta),
             is_neox_style=True,
+            rope_scaling=getattr(config, 'rope_scaling', None),
         )
 
         self.attn = Attention(


### PR DESCRIPTION
Read `rope_scaling` from config if exists.